### PR TITLE
Add MediaPipe logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # mediapipe-example
 
+<p align="center">
+  <img src="https://raw.githubusercontent.com/google/mediapipe/master/docs/images/mediapipe_logo_color.png" alt="MediaPipe Logo" width="200">
+</p>
+
 This project collects sample scripts using **MediaPipe** and `OpenCV` for real-time image analysis such as face detection, Face Mesh, hand tracking, pose detection, and face recognition. They can run on a Raspberry Pi 5 at about 15–25 FPS.
 
 ## Installation


### PR DESCRIPTION
## Summary
- add a centered MediaPipe logo at the top of the README to give the project a more polished look

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf720983dc832bbef62720c7fdb14d